### PR TITLE
Prevent Tracker events being processed by entity processors

### DIFF
--- a/entity_activity_tracker.info.yml
+++ b/entity_activity_tracker.info.yml
@@ -2,6 +2,7 @@ name: 'Entity Activity Tracker'
 type: module
 description: 'Provides a way to track entity activity/popularity'
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Entity Activity Tracker'
 dependencies:
   - drupal:hook_event_dispatcher

--- a/modules/entity_activity_tracker_group/entity_activity_tracker_group.info.yml
+++ b/modules/entity_activity_tracker_group/entity_activity_tracker_group.info.yml
@@ -2,6 +2,7 @@ name: 'Entity Activity Tracker - Group plugins'
 type: module
 description: 'Provides ActivityProcessor plugins specific to group entity type'
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Entity Activity Tracker'
 dependencies:
   - drupal:entity_activity_tracker

--- a/modules/entity_activity_tracker_node/entity_activity_tracker_node.info.yml
+++ b/modules/entity_activity_tracker_node/entity_activity_tracker_node.info.yml
@@ -2,6 +2,7 @@ name: 'Entity Activity Tracker - Node plugins'
 type: module
 description: 'Provides ActivityProcessor plugins specific to node entity type'
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Entity Activity Tracker'
 dependencies:
   - drupal:entity_activity_tracker

--- a/modules/entity_activity_tracker_user/entity_activity_tracker_user.info.yml
+++ b/modules/entity_activity_tracker_user/entity_activity_tracker_user.info.yml
@@ -2,6 +2,7 @@ name: 'Entity Activity Tracker - User plugins'
 type: module
 description: 'Provides ActivityProcessor plugins specific to user entity type'
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Entity Activity Tracker'
 dependencies:
   - drupal:entity_activity_tracker

--- a/src/Plugin/ActivityProcessor/EntityCreate.php
+++ b/src/Plugin/ActivityProcessor/EntityCreate.php
@@ -117,8 +117,13 @@ class EntityCreate extends ActivityProcessorBase implements ActivityProcessorInt
           ? $this->configuration['activity_existing']
           : $this->configuration['activity_creation'];
         foreach ($this->getExistingEntities($event->getTracker()) as $existing_entity) {
-          $activity_record = new ActivityRecord($existing_entity->getEntityTypeId(),
-            $existing_entity->bundle(), $existing_entity->id(), $activity);
+          $activity_record = new ActivityRecord(
+            $existing_entity->getEntityTypeId(),
+            $existing_entity->bundle(),
+            $existing_entity->id(),
+            $activity
+          );
+
           $this->activityRecordStorage->createActivityRecord($activity_record);
         }
         break;
@@ -133,11 +138,10 @@ class EntityCreate extends ActivityProcessorBase implements ActivityProcessorInt
 
       case ActivityEventInterface::TRACKER_DELETE:
         $tracker = $event->getTracker();
+        $activity_records = $this->activityRecordStorage
+          ->getActivityRecords($tracker->getTargetEntityType(), $tracker->getTargetEntityBundle());
         // Get ActivityRecords from this tracker.
-        foreach (
-          $this->activityRecordStorage->getActivityRecords($tracker->getTargetEntityType(),
-            $tracker->getTargetEntityBundle()) as $activity_record
-        ) {
+        foreach ($activity_records as $activity_record) {
           $this->activityRecordStorage->deleteActivityRecord($activity_record);
         }
         break;

--- a/src/Plugin/ActivityProcessor/EntityCreate.php
+++ b/src/Plugin/ActivityProcessor/EntityCreate.php
@@ -106,8 +106,12 @@ class EntityCreate extends ActivityProcessorBase implements ActivityProcessorInt
     switch ($dispatcher_type) {
       case ActivityEventInterface::ENTITY_INSERT:
         $entity = $event->getEntity();
-        $activity_record = new ActivityRecord($entity->getEntityTypeId(), $entity->bundle(),
-          $entity->id(), $this->configuration['activity_creation']);
+        $activity_record = new ActivityRecord(
+          $entity->getEntityTypeId(),
+          $entity->bundle(),
+          $entity->id(),
+          $this->configuration['activity_creation']
+        );
         $this->activityRecordStorage->createActivityRecord($activity_record);
         break;
 

--- a/src/Plugin/ActivityProcessor/EntityCreate.php
+++ b/src/Plugin/ActivityProcessor/EntityCreate.php
@@ -42,7 +42,6 @@ class EntityCreate extends ActivityProcessorBase implements ActivityProcessorInt
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-
     $form['activity_creation'] = [
       '#type' => 'number',
       '#title' => $this->t('Activity on Creation'),
@@ -102,21 +101,24 @@ class EntityCreate extends ActivityProcessorBase implements ActivityProcessorInt
    * {@inheritdoc}
    */
   public function processActivity(Event $event) {
-
     $dispatcher_type = $event->getDispatcherType();
 
     switch ($dispatcher_type) {
       case ActivityEventInterface::ENTITY_INSERT:
         $entity = $event->getEntity();
-        $activity_record = new ActivityRecord($entity->getEntityTypeId(), $entity->bundle(), $entity->id(), $this->configuration['activity_creation']);
+        $activity_record = new ActivityRecord($entity->getEntityTypeId(), $entity->bundle(),
+          $entity->id(), $this->configuration['activity_creation']);
         $this->activityRecordStorage->createActivityRecord($activity_record);
         break;
 
       case ActivityEventInterface::TRACKER_CREATE:
         // Iterate all already existing entities and create a record.
-        $activity = ($this->configuration['activity_existing_enabler']) ? $this->configuration['activity_existing'] : $this->configuration['activity_creation'];
+        $activity = ($this->configuration['activity_existing_enabler'])
+          ? $this->configuration['activity_existing']
+          : $this->configuration['activity_creation'];
         foreach ($this->getExistingEntities($event->getTracker()) as $existing_entity) {
-          $activity_record = new ActivityRecord($existing_entity->getEntityTypeId(), $existing_entity->bundle(), $existing_entity->id(), $activity);
+          $activity_record = new ActivityRecord($existing_entity->getEntityTypeId(),
+            $existing_entity->bundle(), $existing_entity->id(), $activity);
           $this->activityRecordStorage->createActivityRecord($activity_record);
         }
         break;
@@ -132,7 +134,10 @@ class EntityCreate extends ActivityProcessorBase implements ActivityProcessorInt
       case ActivityEventInterface::TRACKER_DELETE:
         $tracker = $event->getTracker();
         // Get ActivityRecords from this tracker.
-        foreach ($this->activityRecordStorage->getActivityRecords($tracker->getTargetEntityType(), $tracker->getTargetEntityBundle()) as $activity_record) {
+        foreach (
+          $this->activityRecordStorage->getActivityRecords($tracker->getTargetEntityType(),
+            $tracker->getTargetEntityBundle()) as $activity_record
+        ) {
           $this->activityRecordStorage->deleteActivityRecord($activity_record);
         }
         break;
@@ -142,7 +147,7 @@ class EntityCreate extends ActivityProcessorBase implements ActivityProcessorInt
   /**
    * Get existing entities of tracker that was just created.
    *
-   * @param \Drupal\entity_activity_tracker\EntityActivityTrackerInterface $tracker
+   * @param \Drupal\entity_activity_tracker\Entity\EntityActivityTrackerInterface $tracker
    *   The tracker config entity.
    *
    * @return \Drupal\Core\Entity\ContentEntityInterface[]
@@ -152,14 +157,17 @@ class EntityCreate extends ActivityProcessorBase implements ActivityProcessorInt
     $storage = $this->entityTypeManager->getStorage($tracker->getTargetEntityType());
     $bundle_key = $storage->getEntityType()->getKey('bundle');
     if (!empty($bundle_key)) {
-      return $this->entityTypeManager->getStorage($tracker->getTargetEntityType())->loadByProperties([$bundle_key => $tracker->getTargetEntityBundle()]);
+      return $this->entityTypeManager
+        ->getStorage($tracker->getTargetEntityType())
+        ->loadByProperties([$bundle_key => $tracker->getTargetEntityBundle()]);
     }
     else {
       // This needs review!! For now should be enough.
       // User entity has no bundles.
-      return $this->entityTypeManager->getStorage($tracker->getTargetEntityType())->loadMultiple();
+      return $this->entityTypeManager
+        ->getStorage($tracker->getTargetEntityType())
+        ->loadMultiple();
     }
-
   }
 
   /**
@@ -168,13 +176,18 @@ class EntityCreate extends ActivityProcessorBase implements ActivityProcessorInt
   public function canProcess(Event $event) {
     // This should change since doesn't make sense to store Entity in event to then
     // load it again.
-    if ($event->getDispatcherType() == ActivityEventInterface::ENTITY_INSERT){
-      $entity = $event->getEntity();
-      $exists = $this->entityTypeManager->getStorage($entity->getEntityTypeId())->load($entity->id());
-      if (empty($exists)) {
-        return ActivityProcessorInterface::SKIP;
-      }
+    if ($event->getDispatcherType() !== ActivityEventInterface::ENTITY_INSERT) {
+      return ActivityProcessorInterface::SKIP;
     }
+
+    $entity = $event->getEntity();
+    $exists = $this->entityTypeManager
+      ->getStorage($entity->getEntityTypeId())
+      ->load($entity->id());
+    if (empty($exists)) {
+      return ActivityProcessorInterface::SKIP;
+    }
+
     return ActivityProcessorInterface::PROCESS;
   }
 

--- a/src/Plugin/ActivityProcessor/EntityDecay.php
+++ b/src/Plugin/ActivityProcessor/EntityDecay.php
@@ -103,8 +103,10 @@ class EntityDecay extends ActivityProcessorBase implements ActivityProcessorInte
       '@decay' => $this->configuration['decay'],
       '@decay_granularity' => $this->configuration['decay_granularity'],
     ];
-    return $this->t('<b>@plugin_name:</b> <br> Type: @decay_type <br> Decay: @decay <br> Granularity: @decay_granularity <br>',
-      $replacements);
+    return $this->t(
+      '<b>@plugin_name:</b> <br> Type: @decay_type <br> Decay: @decay <br> Granularity: @decay_granularity <br>',
+      $replacements
+    );
   }
 
   /**
@@ -132,8 +134,10 @@ class EntityDecay extends ActivityProcessorBase implements ActivityProcessorInte
                 $decay_granularity = $this->configuration['decay_granularity'];
 
                 // Exponential Decay function.
-                $activity_value = ceil($record->getActivityValue() * pow(exp(1),
-                    (-$decay_rate * (($decay_granularity / 60) / 60) / 24)));
+                $activity_value = ceil(
+                  $record->getActivityValue() * pow(exp(1),
+                    (-$decay_rate * (($decay_granularity / 60) / 60) / 24))
+                );
 
                 // @TODO: add threshold value and verify before apply decay.
                 $record->setActivityValue((int) $activity_value);
@@ -157,15 +161,18 @@ class EntityDecay extends ActivityProcessorBase implements ActivityProcessorInte
   /**
    * This returns List of ActivityRecords to Decay.
    *
-   * @param \Drupal\entity_activity_tracker\EntityActivityTrackerInterface $tracker
+   * @param \Drupal\entity_activity_tracker\Entity\EntityActivityTrackerInterface $tracker
    *   The tracker config entity.
    *
    * @return \Drupal\entity_activity_tracker\ActivityRecord[]
    *   List of records to decay.
    */
   protected function recordsToDecay(EntityActivityTrackerInterface $tracker) {
-    return $this->activityRecordStorage->getActivityRecordsLastDecay(time() - $this->configuration['decay_granularity'],
-      $tracker->getTargetEntityType(), $tracker->getTargetEntityBundle());
+    return $this->activityRecordStorage
+      ->getActivityRecordsLastDecay(
+        time() - $this->configuration['decay_granularity'],
+        $tracker->getTargetEntityType(), $tracker->getTargetEntityBundle()
+      );
   }
 
   /**

--- a/src/Plugin/ActivityProcessor/EntityEdit.php
+++ b/src/Plugin/ActivityProcessor/EntityEdit.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\entity_activity_tracker\Plugin\ActivityProcessor;
 
+use Drupal\entity_activity_tracker\Event\EntityActivityBaseEvent;
 use Drupal\entity_activity_tracker\Plugin\ActivityProcessorBase;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\EventDispatcher\Event;
@@ -113,6 +114,10 @@ class EntityEdit extends ActivityProcessorBase implements ActivityProcessorInter
    * {@inheritdoc}
    */
   public function canProcess(Event $event) {
+    if (!$event instanceof EntityActivityBaseEvent) {
+      return ActivityProcessorInterface::SKIP;
+    }
+
     // This should change since doesn't make sense to store Entity in event to then
     // load it again.
     $entity = $event->getEntity();


### PR DESCRIPTION
This PR intends to fixes an issue where tracker events (TrackerCreateEvent) are processed by the canProcess method which leads to the getEntity() call which isn't implemented in these event types